### PR TITLE
Update nginx.conf

### DIFF
--- a/trojan-go\trojan+nginx/nginx.conf
+++ b/trojan-go\trojan+nginx/nginx.conf
@@ -9,7 +9,7 @@ http {
     }
 
     server {
-        listen 127.0.0.1:81; #http/1.1 server，监听本地81端口。
+        listen 0.0.0.0:81; #http/1.1 server，监听本地81端口。
         listen 127.0.0.1:82 http2; #h2c server，监听本地82端口。如为trojan-go提供回落，此项可以删除。
 
         location / {


### PR DESCRIPTION
为 Trojan-go 提供回落时，监听 127.0.0.1:81,
```
curl -v http://127.0.0.1:81
*   Trying 127.0.0.1:81...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 81 (#0)
> GET / HTTP/1.1
> Host: 127.0.0.1:81
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Empty reply from server
* Connection #0 to host 127.0.0.1 left intact
```
监听选择 0.0.0.0:81 时，
```
curl -v http://127.0.0.1:81
*   Trying 127.0.0.1:81...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 81 (#0)
> GET / HTTP/1.1
> Host: 127.0.0.1:81
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 400 Bad Request
< Server: nginx/1.21.6
< Date: Sun, 08 May 2022 13:46:59 GMT
< Content-Type: text/html
< Content-Length: 157
< Connection: close
< Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
< 
<html>
<head><title>400 Bad Request</title></head>
<body>
<center><h1>400 Bad Request</h1></center>
<hr><center>nginx/1.21.6</center>
</body>
</html>
* Closing connection 0
```
可以打开回落网址