### PR TITLE
关于新版 forwardproxy 插件 authentication modules 的变动

### DIFF
--- a/Caddy(N+T)/caddy.json
+++ b/Caddy(N+T)/caddy.json
@@ -30,8 +30,7 @@
           "routes": [{
             "handle": [{
               "handler": "forward_proxy",
-              "auth_user_deprecated": "user", //NaiveProxy 用户，修改为自己的。
-              "auth_pass_deprecated": "pass", //NaiveProxy 密码，修改为自己的。
+              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}
@@ -111,6 +110,10 @@
     }
   }
 }
+//可以使用以下命令生成user:pass二次base64编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、本配置仅支持申请普通 TLS 证书，若要申请通配符 TLS 证书请参考 ‘Caddy(Other Configuration) （Caddy 的特殊应用配置方法。）’ 中对应介绍及对应配置示例。

--- a/Caddy(N+T)/caddy.json
+++ b/Caddy(N+T)/caddy.json
@@ -110,10 +110,6 @@
     }
   }
 }
-//可以使用以下命令生成user:pass二次base64编码后的字符串
-//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
-//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
-//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、本配置仅支持申请普通 TLS 证书，若要申请通配符 TLS 证书请参考 ‘Caddy(Other Configuration) （Caddy 的特殊应用配置方法。）’ 中对应介绍及对应配置示例。
@@ -121,3 +117,7 @@
 //4、本示例使用不同域名来实现介绍中各应用，其办法如下：
 //1）、NaiveProxy 使用 HTTPS 协议时用 z1.xx.yy 域名，使用 QUIC 协议时用 h3.xx.yy 域名。
 //2）、Trojan-Go 使用 Trojan 应用时用 z1.xx.yy 域名，使用 WebSocket 应用时用 z2.xx.yy 域名。
+//5、可以使用以下命令生成 user:pass 二次 base64 编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//6、可以使用以下命令检验 user:pass 二次 base64 编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"

--- a/Caddy(N+T)/caddy.json
+++ b/Caddy(N+T)/caddy.json
@@ -30,7 +30,7 @@
           "routes": [{
             "handle": [{
               "handler": "forward_proxy",
-              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
+              "auth_credentials": ["your_user:pass_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}

--- a/V2Ray(B+D+G+A)+Caddy(N+T)/1_caddy.json
+++ b/V2Ray(B+D+G+A)+Caddy(N+T)/1_caddy.json
@@ -163,10 +163,6 @@
     }
   }
 }
-//可以使用以下命令生成user:pass二次base64编码后的字符串
-//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
-//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
-//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、本配置仅支持申请普通 TLS 证书，若要申请通配符 TLS 证书请参考 ‘Caddy(Other Configuration) （Caddy 的特殊应用配置方法。）’ 中对应介绍及对应配置示例。
@@ -177,3 +173,7 @@
 //3）、Shadowsocks+gRPC+TLS 可随意使用 z1.xx.yy 域名或 z2.xx.yy 域名。
 //4）、NaiveProxy 使用 HTTPS 协议时用 z1.xx.yy 域名，使用 QUIC 协议时用 h3.xx.yy 域名。
 //5）、Trojan-Go 使用 Trojan 应用时用 z1.xx.yy 域名，使用 WebSocket 应用时用 z2.xx.yy 域名。
+//5、可以使用以下命令生成 user:pass 二次 base64 编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//6、可以使用以下命令检验 user:pass 二次 base64 编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"

--- a/V2Ray(B+D+G+A)+Caddy(N+T)/1_caddy.json
+++ b/V2Ray(B+D+G+A)+Caddy(N+T)/1_caddy.json
@@ -83,7 +83,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串 //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
+              "auth_credentials": ["your_user:pass_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串 //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}

--- a/V2Ray(B+D+G+A)+Caddy(N+T)/1_caddy.json
+++ b/V2Ray(B+D+G+A)+Caddy(N+T)/1_caddy.json
@@ -83,8 +83,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_user_deprecated": "user", //NaiveProxy 用户，修改为自己的。
-              "auth_pass_deprecated": "pass", //NaiveProxy 密码，修改为自己的。
+              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串 //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}
@@ -164,6 +163,10 @@
     }
   }
 }
+//可以使用以下命令生成user:pass二次base64编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、本配置仅支持申请普通 TLS 证书，若要申请通配符 TLS 证书请参考 ‘Caddy(Other Configuration) （Caddy 的特殊应用配置方法。）’ 中对应介绍及对应配置示例。

--- a/V2Ray(B+D+G+A)+Caddy(N+T)/2_caddy.json
+++ b/V2Ray(B+D+G+A)+Caddy(N+T)/2_caddy.json
@@ -163,10 +163,6 @@
     }
   }
 }
-//可以使用以下命令生成user:pass二次base64编码后的字符串
-//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
-//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
-//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、本配置仅支持申请普通 TLS 证书，若要申请通配符 TLS 证书请参考 ‘Caddy(Other Configuration) （Caddy 的特殊应用配置方法。）’ 中对应介绍及对应配置示例。
@@ -177,3 +173,7 @@
 //3）、Shadowsocks+gRPC+TLS 可随意使用 z1.xx.yy 域名或 z2.xx.yy 域名。
 //4）、NaiveProxy 使用 HTTPS 协议时用 z1.xx.yy 域名，使用 QUIC 协议时用 h3.xx.yy 域名。
 //5）、Trojan-Go 使用 Trojan 应用时用 z1.xx.yy 域名，使用 WebSocket 应用时用 z2.xx.yy 域名。
+//5、可以使用以下命令生成 user:pass 二次 base64 编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//6、可以使用以下命令检验 user:pass 二次 base64 编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"

--- a/V2Ray(B+D+G+A)+Caddy(N+T)/2_caddy.json
+++ b/V2Ray(B+D+G+A)+Caddy(N+T)/2_caddy.json
@@ -83,7 +83,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
+              "auth_credentials": ["your_user:pass_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}

--- a/V2Ray(B+D+G+A)+Caddy(N+T)/2_caddy.json
+++ b/V2Ray(B+D+G+A)+Caddy(N+T)/2_caddy.json
@@ -83,8 +83,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_user_deprecated": "user", //NaiveProxy 用户，修改为自己的。
-              "auth_pass_deprecated": "pass", //NaiveProxy 密码，修改为自己的。
+              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}
@@ -164,6 +163,10 @@
     }
   }
 }
+//可以使用以下命令生成user:pass二次base64编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、本配置仅支持申请普通 TLS 证书，若要申请通配符 TLS 证书请参考 ‘Caddy(Other Configuration) （Caddy 的特殊应用配置方法。）’ 中对应介绍及对应配置示例。

--- a/Xray(E+F+B+D+G+A)+Caddy(N)+Nginx/1_caddy.json
+++ b/Xray(E+F+B+D+G+A)+Caddy(N)+Nginx/1_caddy.json
@@ -124,7 +124,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
+              "auth_credentials": ["your_user:pass_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}

--- a/Xray(E+F+B+D+G+A)+Caddy(N)+Nginx/1_caddy.json
+++ b/Xray(E+F+B+D+G+A)+Caddy(N)+Nginx/1_caddy.json
@@ -184,12 +184,12 @@
     }
   }
 }
-//可以使用以下命令生成user:pass二次base64编码后的字符串
-//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
-//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
-//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。
 //3、若域名为 zt.xx.yy，那么从 ZeroSSL 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme.zerossl.com-v2-dv90/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。
 //4、本配置仅支持申请普通 TLS 证书，若要申请通配符 TLS 证书请参考 ‘Caddy(Other Configuration) （Caddy 的特殊应用配置方法。）’ 中对应介绍及对应配置示例。
+//5、可以使用以下命令生成 user:pass 二次 base64 编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//6、可以使用以下命令检验 user:pass 二次 base64 编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"

--- a/Xray(E+F+B+D+G+A)+Caddy(N)+Nginx/1_caddy.json
+++ b/Xray(E+F+B+D+G+A)+Caddy(N)+Nginx/1_caddy.json
@@ -124,8 +124,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_user_deprecated": "user", //NaiveProxy 用户，修改为自己的。
-              "auth_pass_deprecated": "pass", //NaiveProxy 密码，修改为自己的。
+              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}
@@ -185,6 +184,10 @@
     }
   }
 }
+//可以使用以下命令生成user:pass二次base64编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。

--- a/Xray(E+F+B+D+G+A)+Caddy(N)+Nginx/2_caddy.json
+++ b/Xray(E+F+B+D+G+A)+Caddy(N)+Nginx/2_caddy.json
@@ -124,7 +124,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
+              "auth_credentials": ["your_user:pass_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}

--- a/Xray(E+F+B+D+G+A)+Caddy(N)+Nginx/2_caddy.json
+++ b/Xray(E+F+B+D+G+A)+Caddy(N)+Nginx/2_caddy.json
@@ -184,12 +184,12 @@
     }
   }
 }
-//可以使用以下命令生成user:pass二次base64编码后的字符串
-//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
-//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
-//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。
 //3、若域名为 zt.xx.yy，那么从 ZeroSSL 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme.zerossl.com-v2-dv90/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。
 //4、本配置仅支持申请普通 TLS 证书，若要申请通配符 TLS 证书请参考 ‘Caddy(Other Configuration) （Caddy 的特殊应用配置方法。）’ 中对应介绍及对应配置示例。
+//5、可以使用以下命令生成 user:pass 二次 base64 编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//6、可以使用以下命令检验 user:pass 二次 base64 编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"

--- a/Xray(E+F+B+D+G+A)+Caddy(N)+Nginx/2_caddy.json
+++ b/Xray(E+F+B+D+G+A)+Caddy(N)+Nginx/2_caddy.json
@@ -124,8 +124,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_user_deprecated": "user", //NaiveProxy 用户，修改为自己的。
-              "auth_pass_deprecated": "pass", //NaiveProxy 密码，修改为自己的。
+              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}
@@ -185,6 +184,10 @@
     }
   }
 }
+//可以使用以下命令生成user:pass二次base64编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。

--- a/Xray(E+F+B+D+G+A)+Caddy(N)/1_caddy.json
+++ b/Xray(E+F+B+D+G+A)+Caddy(N)/1_caddy.json
@@ -173,7 +173,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
+              "auth_credentials": ["your_user:pass_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}

--- a/Xray(E+F+B+D+G+A)+Caddy(N)/1_caddy.json
+++ b/Xray(E+F+B+D+G+A)+Caddy(N)/1_caddy.json
@@ -233,10 +233,6 @@
     }
   }
 }
-//可以使用以下命令生成user:pass二次base64编码后的字符串
-//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
-//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
-//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。
@@ -251,3 +247,7 @@
 //5）、Shadowsocks+gRPC+TLS 可随意使用 zh.xx.yy 域名与 zn.xx.yy 域名。
 //6）、NaiveProxy 仅使用 zn.xx.yy 域名（使用 HTTPS 协议）。
 //7、本示例的 SNI 分流自带限定域名连接（包括禁止以 IP 方式访问网站）。
+//8、可以使用以下命令生成 user:pass 二次 base64 编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//9、可以使用以下命令检验 user:pass 二次 base64 编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"

--- a/Xray(E+F+B+D+G+A)+Caddy(N)/1_caddy.json
+++ b/Xray(E+F+B+D+G+A)+Caddy(N)/1_caddy.json
@@ -173,8 +173,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_user_deprecated": "user", //NaiveProxy 用户，修改为自己的。
-              "auth_pass_deprecated": "pass", //NaiveProxy 密码，修改为自己的。
+              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}
@@ -234,6 +233,10 @@
     }
   }
 }
+//可以使用以下命令生成user:pass二次base64编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。

--- a/Xray(E+F+B+D+G+A)+Caddy(N)/2_caddy.json
+++ b/Xray(E+F+B+D+G+A)+Caddy(N)/2_caddy.json
@@ -173,7 +173,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
+              "auth_credentials": ["your_user:pass_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}

--- a/Xray(E+F+B+D+G+A)+Caddy(N)/2_caddy.json
+++ b/Xray(E+F+B+D+G+A)+Caddy(N)/2_caddy.json
@@ -233,10 +233,6 @@
     }
   }
 }
-//可以使用以下命令生成user:pass二次base64编码后的字符串
-//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
-//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
-//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。 
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。
@@ -251,3 +247,7 @@
 //5）、Shadowsocks+gRPC+TLS 可随意使用 zh.xx.yy 域名与 zn.xx.yy 域名。
 //6）、NaiveProxy 仅使用 zn.xx.yy 域名（使用 HTTPS 协议）。
 //7、本示例的 SNI 分流自带限定域名连接（包括禁止以 IP 方式访问网站）。
+//8、可以使用以下命令生成 user:pass 二次 base64 编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//9、可以使用以下命令检验 user:pass 二次 base64 编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"

--- a/Xray(E+F+B+D+G+A)+Caddy(N)/2_caddy.json
+++ b/Xray(E+F+B+D+G+A)+Caddy(N)/2_caddy.json
@@ -173,8 +173,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_user_deprecated": "user", //NaiveProxy 用户，修改为自己的。
-              "auth_pass_deprecated": "pass", //NaiveProxy 密码，修改为自己的。
+              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}
@@ -234,6 +233,10 @@
     }
   }
 }
+//可以使用以下命令生成user:pass二次base64编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。 
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。

--- a/Xray(M+B+D+G+A)+Caddy(N+T)/1_caddy.json
+++ b/Xray(M+B+D+G+A)+Caddy(N+T)/1_caddy.json
@@ -102,7 +102,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
+              "auth_credentials": ["your_user:pass_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}

--- a/Xray(M+B+D+G+A)+Caddy(N+T)/1_caddy.json
+++ b/Xray(M+B+D+G+A)+Caddy(N+T)/1_caddy.json
@@ -182,10 +182,6 @@
     }
   }
 }
-//可以使用以下命令生成user:pass二次base64编码后的字符串
-//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
-//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
-//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、本配置仅支持申请普通 TLS 证书，若要申请通配符 TLS 证书请参考 ‘Caddy(Other Configuration) （Caddy 的特殊应用配置方法。）’ 中对应介绍及对应配置示例。
@@ -197,3 +193,7 @@
 //4）、Shadowsocks+gRPC+TLS 可随意使用 z2.xx.yy 域名与 z3.xx.yy 域名。
 //5）、NaiveProxy 仅使用 z3.xx.yy 域名（使用 HTTPS 协议）。
 //6）、Trojan-Go 使用 Trojan 应用时用 z3.xx.yy 域名，使用 WebSocket 应用时用 z2.xx.yy 域名。
+//5、可以使用以下命令生成 user:pass 二次 base64 编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//6、可以使用以下命令检验 user:pass 二次 base64 编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"

--- a/Xray(M+B+D+G+A)+Caddy(N+T)/1_caddy.json
+++ b/Xray(M+B+D+G+A)+Caddy(N+T)/1_caddy.json
@@ -102,8 +102,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_user_deprecated": "user", //NaiveProxy 用户，修改为自己的。
-              "auth_pass_deprecated": "pass", //NaiveProxy 密码，修改为自己的。
+              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}
@@ -183,6 +182,10 @@
     }
   }
 }
+//可以使用以下命令生成user:pass二次base64编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、本配置仅支持申请普通 TLS 证书，若要申请通配符 TLS 证书请参考 ‘Caddy(Other Configuration) （Caddy 的特殊应用配置方法。）’ 中对应介绍及对应配置示例。

--- a/Xray(M+B+D+G+A)+Caddy(N+T)/2_caddy.json
+++ b/Xray(M+B+D+G+A)+Caddy(N+T)/2_caddy.json
@@ -197,3 +197,7 @@
 //4）、Shadowsocks+gRPC+TLS 可随意使用 z2.xx.yy 域名与 z3.xx.yy 域名。
 //5）、NaiveProxy 仅使用 z3.xx.yy 域名（使用 HTTPS 协议）。
 //6）、Trojan-Go 使用 Trojan 应用时用 z3.xx.yy 域名，使用 WebSocket 应用时用 z2.xx.yy 域名。
+//5、可以使用以下命令生成 user:pass 二次 base64 编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//6、可以使用以下命令检验 user:pass 二次 base64 编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"

--- a/Xray(M+B+D+G+A)+Caddy(N+T)/2_caddy.json
+++ b/Xray(M+B+D+G+A)+Caddy(N+T)/2_caddy.json
@@ -102,7 +102,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
+              "auth_credentials": ["your_user:pass_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}

--- a/Xray(M+B+D+G+A)+Caddy(N+T)/2_caddy.json
+++ b/Xray(M+B+D+G+A)+Caddy(N+T)/2_caddy.json
@@ -182,10 +182,6 @@
     }
   }
 }
-//可以使用以下命令生成user:pass二次base64编码后的字符串
-//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
-//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
-//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、本配置仅支持申请普通 TLS 证书，若要申请通配符 TLS 证书请参考 ‘Caddy(Other Configuration) （Caddy 的特殊应用配置方法。）’ 中对应介绍及对应配置示例。

--- a/Xray(M+B+D+G+A)+Caddy(N+T)/2_caddy.json
+++ b/Xray(M+B+D+G+A)+Caddy(N+T)/2_caddy.json
@@ -102,8 +102,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_user_deprecated": "user", //NaiveProxy 用户，修改为自己的。
-              "auth_pass_deprecated": "pass", //NaiveProxy 密码，修改为自己的。
+              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}
@@ -183,6 +182,10 @@
     }
   }
 }
+//可以使用以下命令生成user:pass二次base64编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、本配置仅支持申请普通 TLS 证书，若要申请通配符 TLS 证书请参考 ‘Caddy(Other Configuration) （Caddy 的特殊应用配置方法。）’ 中对应介绍及对应配置示例。

--- a/Xray(M+F+B+D+G+A)+Caddy(N)+Nginx/1_caddy.json
+++ b/Xray(M+F+B+D+G+A)+Caddy(N)+Nginx/1_caddy.json
@@ -124,7 +124,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
+              "auth_credentials": ["your_user:pass_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}

--- a/Xray(M+F+B+D+G+A)+Caddy(N)+Nginx/1_caddy.json
+++ b/Xray(M+F+B+D+G+A)+Caddy(N)+Nginx/1_caddy.json
@@ -184,12 +184,12 @@
     }
   }
 }
-//可以使用以下命令生成user:pass二次base64编码后的字符串
-//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
-//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
-//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。
 //3、若域名为 zt.xx.yy，那么从 ZeroSSL 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme.zerossl.com-v2-dv90/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。
 //4、本配置仅支持申请普通 TLS 证书，若要申请通配符 TLS 证书请参考 ‘Caddy(Other Configuration) （Caddy 的特殊应用配置方法。）’ 中对应介绍及对应配置示例。
+//5、可以使用以下命令生成 user:pass 二次 base64 编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//6、可以使用以下命令检验 user:pass 二次 base64 编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"

--- a/Xray(M+F+B+D+G+A)+Caddy(N)+Nginx/1_caddy.json
+++ b/Xray(M+F+B+D+G+A)+Caddy(N)+Nginx/1_caddy.json
@@ -124,8 +124,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_user_deprecated": "user", //NaiveProxy 用户，修改为自己的。
-              "auth_pass_deprecated": "pass", //NaiveProxy 密码，修改为自己的。
+              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}
@@ -185,6 +184,10 @@
     }
   }
 }
+//可以使用以下命令生成user:pass二次base64编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。

--- a/Xray(M+F+B+D+G+A)+Caddy(N)+Nginx/2_caddy.json
+++ b/Xray(M+F+B+D+G+A)+Caddy(N)+Nginx/2_caddy.json
@@ -124,7 +124,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
+              "auth_credentials": ["your_user:pass_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}

--- a/Xray(M+F+B+D+G+A)+Caddy(N)+Nginx/2_caddy.json
+++ b/Xray(M+F+B+D+G+A)+Caddy(N)+Nginx/2_caddy.json
@@ -184,12 +184,12 @@
     }
   }
 }
-//可以使用以下命令生成user:pass二次base64编码后的字符串
-//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
-//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
-//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。
 //3、若域名为 zt.xx.yy，那么从 ZeroSSL 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme.zerossl.com-v2-dv90/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。
 //4、本配置仅支持申请普通 TLS 证书，若要申请通配符 TLS 证书请参考 ‘Caddy(Other Configuration) （Caddy 的特殊应用配置方法。）’ 中对应介绍及对应配置示例。
+//5、可以使用以下命令生成 user:pass 二次 base64 编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//6、可以使用以下命令检验 user:pass 二次 base64 编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"

--- a/Xray(M+F+B+D+G+A)+Caddy(N)+Nginx/2_caddy.json
+++ b/Xray(M+F+B+D+G+A)+Caddy(N)+Nginx/2_caddy.json
@@ -124,8 +124,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_user_deprecated": "user", //NaiveProxy 用户，修改为自己的。
-              "auth_pass_deprecated": "pass", //NaiveProxy 密码，修改为自己的。
+              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}
@@ -185,6 +184,10 @@
     }
   }
 }
+//可以使用以下命令生成user:pass二次base64编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。

--- a/Xray(M+F+B+D+G+A)+Caddy(N)/1_caddy.json
+++ b/Xray(M+F+B+D+G+A)+Caddy(N)/1_caddy.json
@@ -173,7 +173,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
+              "auth_credentials": ["your_user:pass_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}

--- a/Xray(M+F+B+D+G+A)+Caddy(N)/1_caddy.json
+++ b/Xray(M+F+B+D+G+A)+Caddy(N)/1_caddy.json
@@ -233,10 +233,6 @@
     }
   }
 }
-//可以使用以下命令生成user:pass二次base64编码后的字符串
-//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
-//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
-//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。
@@ -251,3 +247,7 @@
 //5）、Shadowsocks+gRPC+TLS 可随意使用 zh.xx.yy 域名与 zn.xx.yy 域名。
 //6）、NaiveProxy 仅使用 zn.xx.yy 域名（使用 HTTPS 协议）。
 //7、本示例的 SNI 分流自带限定域名连接（包括禁止以 IP 方式访问网站）。
+//8、可以使用以下命令生成 user:pass 二次 base64 编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//9、可以使用以下命令检验 user:pass 二次 base64 编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"

--- a/Xray(M+F+B+D+G+A)+Caddy(N)/1_caddy.json
+++ b/Xray(M+F+B+D+G+A)+Caddy(N)/1_caddy.json
@@ -173,8 +173,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_user_deprecated": "user", //NaiveProxy 用户，修改为自己的。
-              "auth_pass_deprecated": "pass", //NaiveProxy 密码，修改为自己的。
+              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}
@@ -234,6 +233,10 @@
     }
   }
 }
+//可以使用以下命令生成user:pass二次base64编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。

--- a/Xray(M+F+B+D+G+A)+Caddy(N)/2_caddy.json
+++ b/Xray(M+F+B+D+G+A)+Caddy(N)/2_caddy.json
@@ -173,7 +173,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
+              "auth_credentials": ["your_user:pass_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}

--- a/Xray(M+F+B+D+G+A)+Caddy(N)/2_caddy.json
+++ b/Xray(M+F+B+D+G+A)+Caddy(N)/2_caddy.json
@@ -233,10 +233,6 @@
     }
   }
 }
-//可以使用以下命令生成user:pass二次base64编码后的字符串
-//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
-//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
-//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。
@@ -251,3 +247,7 @@
 //5）、Shadowsocks+gRPC+TLS 可随意使用 zh.xx.yy 域名与 zn.xx.yy 域名。
 //6）、NaiveProxy 仅使用 zn.xx.yy 域名（使用 HTTPS 协议）。
 //7、本示例的 SNI 分流自带限定域名连接（包括禁止以 IP 方式访问网站）。
+//8、可以使用以下命令生成 user:pass 二次 base64 编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//9、可以使用以下命令检验 user:pass 二次 base64 编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"

--- a/Xray(M+F+B+D+G+A)+Caddy(N)/2_caddy.json
+++ b/Xray(M+F+B+D+G+A)+Caddy(N)/2_caddy.json
@@ -173,8 +173,7 @@
           {
             "handle": [{
               "handler": "forward_proxy",
-              "auth_user_deprecated": "user", //NaiveProxy 用户，修改为自己的。
-              "auth_pass_deprecated": "pass", //NaiveProxy 密码，修改为自己的。
+              "auth_credentials": ["your_base64"] //输入将NaiveProxy的user:pass二次base64编码后所得的字符串
               "hide_ip": true,
               "hide_via": true,
               "probe_resistance": {}
@@ -234,6 +233,10 @@
     }
   }
 }
+//可以使用以下命令生成user:pass二次base64编码后的字符串
+//$ echo -n "user:pass" | base64 | tr -d '\n' | base64
+//可以使用以下命令检验user:pass二次base64编码后的字符串是否正确
+//$ echo -e "$(echo "your_user:pass_base64" | base64 --decode | base64 --decode)"
 //备注：
 //1、申请免费 TLS 证书的域名不要超过五个，否则影响 TLS 证书的更新。
 //2、若域名为 zt.xx.yy，那么从 Let's Encrypt 申请的普通 TLS 证书在 ‘/home/tls/certificates/acme-v02.api.letsencrypt.org-directory/zt.xx.yy’ 目录中。/home/tls 为存放 TLS 证书的基本路径，目录随域名变化。


### PR DESCRIPTION
新版 forwardproxy 插件已弃用了以下字段：
``` json
"auth_user_deprecated": "user",
"auth_pass_deprecated": "pass",
```
新版 forwardproxy 插件需改为使用以下字段来设置 authentication 信息：
``` json
"auth_credentials": ["your_user:pass_base64"],
```
ps:仅修改了caddy.json文件，此次PR未对README.md文件进行任何修改